### PR TITLE
Add query check that it does not cause error during teardown step

### DIFF
--- a/src/Context/Drupal/AppContentEntitySetupTearDown.php
+++ b/src/Context/Drupal/AppContentEntitySetupTearDown.php
@@ -153,7 +153,7 @@ class AppContentEntitySetupTearDown extends Base
             $entityType = $etm->getDefinition($entityTypeId);
             $storage = $etm->getStorage($entityTypeId);
 
-            $query = $storage->getQuery();
+            $query = $storage->getQuery()->accessCheck(FALSE);
 
             if ($entityId === null) {
                 $storage->resetCache();


### PR DESCRIPTION
I got the next error during behat test running. 

> 8192: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /app/vendor/symfony/http-foundation/Request.php line 1238

I turned out it's caused by execute() method the querry.